### PR TITLE
fix: Secure password change with hashing

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 from app.services.auth_service import AuthService
-from app.schemas.user import UserCreate, UserOut
+from app.schemas.user import UserCreate, UserOut, ChangePassword
 
 router = APIRouter(prefix = "/auth", tags = ["Authentication"])
 
@@ -17,3 +17,7 @@ def login(username: str, password: str):
     if not user:
         raise HTTPException(status_code = 401, detail = "Incorrect email or password")
     return user
+
+@router.patch("/change-password/{user_id}", status_code = status.HTTP_204_NO_CONTENT)
+def change_password(user_id: int, payload: ChangePassword):
+    AuthService().change_password(user_id, payload.old_password, payload.new_password)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -30,7 +30,6 @@ class UserOut(BaseModel):
 
 class UserUpdate(BaseModel):
     username: str
-    password: str
     email: str
     isAdmin: bool
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -29,3 +29,12 @@ class AuthService:
         if user_dict and checkpw(password.encode('utf-8'), user_dict["password"].encode('utf-8')):
             return User(**user_dict)
         return None
+    
+    def change_password(self, user_id: int, old_password: str, new_password: str):
+        user_dict = get_user_by_id(user_id)
+        if not user_dict:
+            raise ValueError("User not found")
+        if not checkpw(old_password.encode('utf-8'), user_dict["password"].encode('utf-8')):
+            raise ValueError("Incorrect password")
+        new_hashed = hashpw(new_password.encode('utf-8'), gensalt()).decode('utf-8')
+        update_user(user_id, {"password": new_hashed})


### PR DESCRIPTION
Added hashing to change_user_password() in auth_service. Reuses bcrypt from registration and thus has no plaintext storage (as per M1 security).

deleted the change password line from UserUpdate schema as it seemed redundant(?)




